### PR TITLE
Set Panels Field to Pedro Pathing in Tuning

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
@@ -89,6 +89,8 @@ public class Tuning extends SelectableOpMode {
         poseHistory = follower.getPoseHistory();
 
         telemetryM = PanelsTelemetry.INSTANCE.getTelemetry();
+
+        Drawing.init();
     }
 
     @Override


### PR DESCRIPTION
Fixes a small issue where the Panels field offsets are never set in the Tuning file because Drawing.init() is never called.