### PR TITLE
Fix path drawing

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
@@ -1209,11 +1209,16 @@ class Drawing {
      * @param follower Pedro Follower instance.
      */
     public static void drawDebug(Follower follower) {
-        if (follower.getCurrentPath() != null) {
+        if (follower.getCurrentPathChain() != null && follower.getCurrentPath() != null) {
+            drawPath(follower.getCurrentPathChain(), robotLook);
+            Pose closestPoint = follower.getPointFromPath(follower.getCurrentPath().getClosestPointTValue());
+            drawRobot(new Pose(closestPoint.getX(), closestPoint.getY(), follower.getCurrentPath().getHeadingGoal(follower.getCurrentPath().getClosestPointTValue())), robotLook);
+        } else if (follower.getCurrentPath() != null) {
             drawPath(follower.getCurrentPath(), robotLook);
             Pose closestPoint = follower.getPointFromPath(follower.getCurrentPath().getClosestPointTValue());
             drawRobot(new Pose(closestPoint.getX(), closestPoint.getY(), follower.getCurrentPath().getHeadingGoal(follower.getCurrentPath().getClosestPointTValue())), robotLook);
         }
+        
         drawPoseHistory(follower.getPoseHistory(), historyLook);
         drawRobot(follower.getPose(), historyLook);
 
@@ -1273,8 +1278,10 @@ class Drawing {
         }
 
         panelsField.setStyle(style);
-        panelsField.moveCursor(points[0][0], points[0][1]);
-        panelsField.line(points[1][0], points[1][1]);
+        for (int i = 0; i < points[0].length - 1; i++) {
+            panelsField.moveCursor(points[0][i], points[1][i]);
+            panelsField.line(points[0][i + 1], points[1][i + 1]);
+        }
     }
 
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
@@ -1210,7 +1210,7 @@ class Drawing {
      */
     public static void drawDebug(Follower follower) {
         if (follower.getCurrentPath() != null) {
-            drawPath(follower.getCurrentPath(), robotLook);
+            drawPath(follower.getCurrentPathChain(), robotLook);
             Pose closestPoint = follower.getPointFromPath(follower.getCurrentPath().getClosestPointTValue());
             drawRobot(new Pose(closestPoint.getX(), closestPoint.getY(), follower.getCurrentPath().getHeadingGoal(follower.getCurrentPath().getClosestPointTValue())), robotLook);
         }
@@ -1273,8 +1273,10 @@ class Drawing {
         }
 
         panelsField.setStyle(style);
-        panelsField.moveCursor(points[0][0], points[0][1]);
-        panelsField.line(points[1][0], points[1][1]);
+        for (int i = 0; i < points[0].length - 1; i++) {
+            panelsField.moveCursor(points[0][i], points[1][i]);
+            panelsField.line(points[0][i + 1], points[1][i + 1]);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR updates the drawDebug method to draw the full path chain rather than just the first path segment, and fixes path drawing so that correctly iterates through all  points of the line.

Previously, drawDebug would only draw the current segment, when it makes more sense to draw the entire current pathChain. Additionally, drawPath would only draw points 0 and 1 of the given Path, causing very odd visualizations:
<img width="703" height="703" alt="field" src="https://github.com/user-attachments/assets/fe2c84d7-f24f-4378-a49d-2f1607c5c066" />
After this update, drawPath correctly iterates through and draws each point of the path.
