### PR TITLE
Add Line Tuner to Manual tuning options

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
@@ -65,6 +65,7 @@ public class Tuning extends SelectableOpMode {
                 p.add("Translational Tuner", TranslationalTuner::new);
                 p.add("Heading Tuner", HeadingTuner::new);
                 p.add("Drive Tuner", DriveTuner::new);
+                p.add("Line Tuner", Line::new);
                 p.add("Centripetal Tuner", CentripetalTuner::new);
             });
             s.folder("Tests", p -> {


### PR DESCRIPTION
This PR implements a Discord Suggestion: https://discord.com/channels/1262595185699717140/1437794496833130546

Puts Line Test tuner in "Manual" tuners tab. Should make it simpler to tune Drive PIDF, since the Translational + Heading are going to be activated. Docs will be updated to explain the changes.