### PR TITLE
fix: mistake-pr workflow on every fork

### DIFF
--- a/.github/workflows/disable-auto-reopen-after-second-close.yml
+++ b/.github/workflows/disable-auto-reopen-after-second-close.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   disable:
+    if: github.repository == 'Pedro-Pathing/Quickstart'
     runs-on: ubuntu-latest
     steps:
       - name: Disable automatic reopen

--- a/.github/workflows/mistake-pr.yml
+++ b/.github/workflows/mistake-pr.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   detect:
+    if: github.repository == 'Pedro-Pathing/Quickstart'
     runs-on: ubuntu-latest
     steps:
       - name: Detect mistake PR

--- a/.github/workflows/reopen-once.yml
+++ b/.github/workflows/reopen-once.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   reopen:
+    if: github.repository == 'Pedro-Pathing/Quickstart'
     runs-on: ubuntu-latest
     steps:
       - name: Handle /not-a-mistake


### PR DESCRIPTION
I don't believe that the mistake-pr workflow should run on every single fork of this template repository. It seems to just be a check for this template to prevent spam prs. As such, I've added a single check to make sure that it only runs on this specific repository. 