### PR TITLE
re-add exclude block to pedro dependency

### DIFF
--- a/build.dependencies.gradle
+++ b/build.dependencies.gradle
@@ -19,6 +19,8 @@ dependencies {
     implementation 'org.firstinspires.ftc:Vision:11.2.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    implementation 'com.pedropathing:revhub:3.0.0-SNAPSHOT'
+    implementation ('com.pedropathing:revhub:3.0.0-SNAPSHOT'){
+        exclude group: 'org.aspectj', module: 'aspectjtools'
+    }
 }
 


### PR DESCRIPTION
Exclude aspectjtools from pedro dependency like it was before until it disappeared :(

Before issuing a pull request, please see the contributing page.
