### PR TITLE
Fix lateral Automatic tuner telemetry: robot moves left, not right

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java
@@ -483,7 +483,7 @@ class LateralVelocityTuner extends OpMode {
      */
     @Override
     public void init_loop() {
-        telemetryM.debug("The robot will run at 1 power until it reaches " + DISTANCE + " inches to the right.");
+        telemetryM.debug("The robot will run at 1 power until it reaches " + DISTANCE + " inches to the left.");
         telemetryM.debug("Make sure you have enough room, since the robot has inertia after cutting power.");
         telemetryM.debug("After running the distance, the robot will cut power from the drivetrain and display the strafe velocity.");
         telemetryM.debug("Press B on Gamepad 1 to stop.");
@@ -493,7 +493,7 @@ class LateralVelocityTuner extends OpMode {
         drawCurrent();
     }
 
-    /** This starts the OpMode by setting the drive motors to run right at full power. */
+    /** This starts the OpMode by setting the drive motors to run left at full power. */
     @Override
     public void start() {
         for (int i = 0; i < RECORD_NUMBER; i++) {
@@ -659,7 +659,7 @@ class ForwardZeroPowerAccelerationTuner extends OpMode {
 
 /**
  * This is the LateralZeroPowerAccelerationTuner autonomous follower OpMode. This runs the robot
- * to the right until a specified velocity is achieved. Then, the robot cuts power to the motors, setting
+ * to the left until a specified velocity is achieved. Then, the robot cuts power to the motors, setting
  * them to zero power. The deceleration, or negative acceleration, is then measured until the robot
  * stops. The accelerations across the entire time the robot is slowing down is then averaged and
  * that number is then printed. This is used to determine how the robot will decelerate in the
@@ -688,7 +688,7 @@ class LateralZeroPowerAccelerationTuner extends OpMode {
     /** This initializes the drive motors as well as the Panels telemetry. */
     @Override
     public void init_loop() {
-        telemetryM.debug("The robot will run to the right until it reaches " + VELOCITY + " inches per second.");
+        telemetryM.debug("The robot will run to the left until it reaches " + VELOCITY + " inches per second.");
         telemetryM.debug("Then, it will cut power from the drivetrain and roll to a stop.");
         telemetryM.debug("Make sure you have enough room.");
         telemetryM.debug("After stopping, the lateral zero power acceleration (natural deceleration) will be displayed.");


### PR DESCRIPTION
## The bug

Both `LateralVelocityTuner` and `LateralZeroPowerAccelerationTuner` in `TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Tuning.java` call `follower.setTeleOpDrive(0, 1, 0, true)` — positive lateral — but their telemetry/comment text tells the driver the robot will move **right**. It actually moves **left**.

## Why positive lateral is left

Pedro's own reference teleop in the same file (around line 183) does:

```java
follower.setTeleOpDrive(-gamepad1.left_stick_y, -gamepad1.left_stick_x, -gamepad1.right_stick_x, true);
```

FTC's `gamepad.left_stick_x` is positive to the right. Negating it means pushing the stick right passes a *negative* lateral value. For that teleop to drive right when the stick is pushed right, negative lateral must be right — so positive lateral is left, the standard robotics +Y convention.

The Pedro Pathing docs already say the robot moves left for both of these tuners:
- https://pedropathing.com/docs/pathing/tuning/automatic#lateral-velocity-tuner
- https://pedropathing.com/docs/pathing/tuning/automatic#lateral-zero-power-acceleration

So the docs are correct; only the on-robot telemetry/comment text is wrong.

## Previously reported, never landed

This has been reported twice before, but neither fix made it to `master`:
- #12 "Update LateralVelocityTuner instructions to move to the left" — closed 2025-09-27
- #22 "Fix direction typo(change right to left) in Lateral Zero Power Acceleration tuner." — closed 2025-12-27

This PR covers both call sites at once so the fix actually lands.

## Impact

Cosmetic/text-only — lateral velocity and deceleration are symmetric, so tuning *results* remain valid regardless of the label. But it costs real debugging time: a team following the on-screen instruction sees the robot move the "wrong" way and can reasonably suspect their motor directions or localizer are misconfigured. It can also lead to staging the robot with clearance on the wrong side before a full-power run.

## Changes

- `LateralVelocityTuner` telemetry (was line 486): "... inches to the right." -> "... inches to the left."
- `LateralVelocityTuner` `start()` javadoc (was line 496): "run right at full power" -> "run left at full power" (found while checking the class for consistency — matches the pattern used by `ForwardVelocityTuner`'s "run forward at full power")
- `LateralZeroPowerAccelerationTuner` class javadoc (was line 662): "to the right until a specified velocity" -> "to the left until a specified velocity"
- `LateralZeroPowerAccelerationTuner` telemetry (was line 691): "run to the right until it reaches" -> "run to the left until it reaches"

Diff is 4 single-line text changes, nothing else touched.

## Not changed (worth a separate look, unverified)

The manual `LateralTuner`'s telemetry says `"Pull your robot to the right ... inches"`. That tuner works by the user pushing the robot by hand, so its correctness depends on the strafe encoder sign rather than on `setTeleOpDrive`. I have not verified whether it's correct, so I left it alone — flagging in case maintainers want to check it separately.

Thanks for maintaining this project!